### PR TITLE
improve arabic translations

### DIFF
--- a/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
@@ -26,7 +26,7 @@
 
 
 "Settings.ChatList.Header" = "قائمة الفواصل";
-"Settings.CompactChatList" = "قائمة المحادثات المصغرة";
+"Settings.CompactChatList" = "قائمة الدردشة المتراصة";
 
 "Settings.Profiles.Header" = "الملفات الشخصية";
 

--- a/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/ar.lproj/SGLocalizable.strings
@@ -26,11 +26,11 @@
 
 
 "Settings.ChatList.Header" = "قائمة الفواصل";
-"Settings.CompactChatList" = "قائمة الدردشة المدمجة";
+"Settings.CompactChatList" = "قائمة المحادثات المصغرة";
 
-"Settings.Profiles.Header" = "PROFILES";
+"Settings.Profiles.Header" = "الملفات الشخصية";
 
-"Settings.Stories.Hide" = "إخفاء الستوري";
+"Settings.Stories.Hide" = "إخفاء القصص";
 "Settings.Stories.WarnBeforeView" = "اسأل قبل العرض";
 "Settings.Stories.DisableSwipeToRecord" = "تعطيل السحب للتسجيل";
 
@@ -95,7 +95,7 @@
 "ContextMenu.SaveToCloud" = "الحفظ في السحابة";
 "ContextMenu.SelectFromUser" = "حدد من المؤلف";
 
-"Settings.ContextMenu" = "قائمة الإتصال";
+"Settings.ContextMenu" = "قائمة السياق";
 "Settings.ContextMenu.Notice" = "المدخلات المعطلة ستكون متوفرة في القائمة الفرعية \"Swiftgram\".";
 
 
@@ -115,8 +115,8 @@
 
 "Settings.RecordingButton" = "زر التسجيل الصوتي";
 
-"Settings.DefaultEmojisFirst" = "الأفضلية للرموز التعبيرية القياسية";
-"Settings.DefaultEmojisFirst.Notice" = "عرض الرموز التعبيرية القياسية قبل الرموز المتميزة في لوحة المفاتيح";
+"Settings.DefaultEmojisFirst" = "الأفضلية للرموز التعبيرية الافتراضية
+"Settings.DefaultEmojisFirst.Notice" = "عرض الرموز التعبيرية الافتراضية قبل الرموز المتميزة في لوحة المفاتيح";
 
 /* Date when chat was created. "created: 24 May 2016" */
 "Chat.Created" = "تم إنشاؤه: %@";
@@ -128,10 +128,10 @@
 
 "Settings.messageDoubleTapActionOutgoingEdit" = "اضغط مزدوجًا لتحرير الرسالة";
 
-"Settings.wideChannelPosts" = "المشاركات الواسعة في القنوات";
+"Settings.wideChannelPosts" = "المنشورات الواسعة في القنوات";
 "Settings.ForceEmojiTab" = "لوحة مفاتيح الرموز التعبيرية افتراضيًا";
 
-"Settings.forceBuiltInMic" = "قوة ميكروفون الجهاز";
+"Settings.forceBuiltInMic" = "فرض استخدام مايكروفون الجهاز";
 "Settings.forceBuiltInMic.Notice" = "إذا تم تمكينه، سيستخدم التطبيق فقط ميكروفون الجهاز حتى لو كانت سماعات الرأس متصلة.";
 
-"Settings.hideChannelBottomButton" = "إخفاء لوحة قاعدة القناة";
+"Settings.hideChannelBottomButton" = "إخفاء الزر في أسفل القناة";


### PR DESCRIPTION
some translations was wrong, like `forceBuiltInMic` it was translated to "قوة ميكروفون الجهاز", and that's mean "Power of built-in microphone", not "Force built-in mic", all the wrong translations fixed now.
 