### PR TITLE
Fix bottom nav bar width when Calls tab is hidden

### DIFF
--- a/submodules/TelegramUI/Components/TabBarComponent/Sources/TabBarComponent.swift
+++ b/submodules/TelegramUI/Components/TabBarComponent/Sources/TabBarComponent.swift
@@ -606,7 +606,7 @@ public final class TabBarComponent: Component {
                 case 2:
                     widthReducer = 1.5
                 case 3:
-                    widthReducer = 1.25
+                    widthReducer = 1.0
                 case 4:
                     widthReducer = 1.0
                 default:


### PR DESCRIPTION
When the Calls tab is hidden via Settings, the tab bar shrank to ~80% 
width due to a widthReducer of 1.25 being applied for 3-item layouts, 
creating a floating pill appearance instead of a full-width bar.

Changed widthReducer for 3 items from 1.25 → 1.0.

**Before:**
![IMG_0826](https://github.com/user-attachments/assets/9532be7e-3b9f-4246-96be-8b561cb23263)


**After:**
![IMG_0824](https://github.com/user-attachments/assets/af7bee2e-3e04-4adb-a085-9f39648395b7)