### PR TITLE
Fix: Settings stack navigation

### DIFF
--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreenSettingsActions.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoScreenSettingsActions.swift
@@ -25,7 +25,7 @@ extension PeerInfoScreenNode {
                 return
             }
             
-            if strongSelf.isMyProfile {
+            if strongSelf.isMyProfile || strongSelf.isSettings { // MARK: Swiftgram
                 navigationController.pushViewController(c)
             } else {
                 var updatedControllers = navigationController.viewControllers
@@ -85,7 +85,7 @@ extension PeerInfoScreenNode {
                     return
                 }
                 if let controller = self.controller, let navigationController = controller.navigationController as? NavigationController {
-                    self.context.sharedContext.navigateToChatController(NavigateToChatControllerParams(navigationController: navigationController, context: self.context, chatLocation: .peer(peer)))
+                    self.context.sharedContext.navigateToChatController(NavigateToChatControllerParams(navigationController: navigationController, context: self.context, chatLocation: .peer(peer), keepStack: .always)) // MARK: Swiftgram
                 }
             })
         case .recentCalls:
@@ -386,7 +386,7 @@ extension PeerInfoScreenNode {
         |> deliverOnMainQueue).startStrict(next: { [weak controller] peer in
             controller?.dismiss()
             if let peer = peer, let navigationController = navigationController {
-                context.sharedContext.navigateToChatController(NavigateToChatControllerParams(navigationController: navigationController, context: context, chatLocation: .peer(peer)))
+                context.sharedContext.navigateToChatController(NavigateToChatControllerParams(navigationController: navigationController, context: context, chatLocation: .peer(peer), keepStack: .always)) // MARK: Swiftgram
             }
         }))
     }


### PR DESCRIPTION
## Было

- При открытии вложенного экрана настроек из запушенного Settings экран пересобирал navigation stack до TabBarController.
- Из-за этого сам экран Settings исчезал из back stack.
- Saved Messages и Telegram Features/Tips обходили общий settings push path через chat navigation и тоже могли выкинуть Settings из стека.

## Стало

- Для Settings screen используется обычный pushViewController.
- Settings остается в navigation stack, а дочерний экран настроек пушится поверх.
- Saved Messages и Telegram Features/Tips открываются с keepStack: .always, поэтому Settings сохраняется при переходе в эти чаты.