### PR TITLE
Fix MtProtoKit: SOCKS5 proxy IPv6 connect sent garbage address

### DIFF
--- a/submodules/MtProtoKit/Sources/MTTcpConnection.m
+++ b/submodules/MtProtoKit/Sources/MTTcpConnection.m
@@ -1438,15 +1438,37 @@ struct ctr_state {
 
 - (void)requestSocksConnection {
     struct socks5_req req;
-    
+
     req.Version = 5;
     req.Cmd = 1;
     req.Reserved = 0;
-    req.AddrType = 1;
-    
+
+    // MARK: Swiftgram
+    // Upstream hardcoded AddrType=1 and ignored inet_aton's return value, so IPv6 DC
+    // addresses got sent as ATYP=1 with garbage (uninitialized) bytes. Detect IPv4/IPv6
+    // properly, same as -start does for _socksIp/_mtpIp. Domain name (ATYP=3) fallback
+    // per SOCKS5 spec (RFC 1928 part 4), for non-IP-literal addresses,
+    // bounds-checked against the 256-byte Domain buffer.
     struct in_addr ip4;
-    inet_aton(_scheme.address.ip.UTF8String, &ip4);
-    req.DestAddr.IPv4 = ip4;
+    struct in6_addr ip6;
+    NSString *destAddress = _scheme.address.ip;
+    if (inet_aton(destAddress.UTF8String, &ip4) != 0) {
+        req.AddrType = 1;
+        req.DestAddr.IPv4 = ip4;
+    } else if (inet_pton(AF_INET6, destAddress.UTF8String, &ip6) != 0) {
+        req.AddrType = 4;
+        req.DestAddr.IPv6 = ip6;
+    } else if (destAddress.length <= 255 && [destAddress getCString:req.DestAddr.Domain maxLength:sizeof(req.DestAddr.Domain) encoding:NSASCIIStringEncoding]) {
+        req.AddrType = 3;
+        req.DestAddr.DomainLen = (unsigned char)destAddress.length;
+    } else {
+        if (MTLogEnabled()) {
+            MTLog(@"***** %s: could not parse destination address %@", __PRETTY_FUNCTION__, destAddress);
+        }
+        [self closeAndNotifyWithError:true];
+        return;
+    }
+
     req.DestPort = _scheme.address.port;
     
     NSMutableData *reqData = [[NSMutableData alloc] init];


### PR DESCRIPTION
## Problem

Users on SOCKS5 proxy fail to connect when the resolved DC address is IPv6 connection spins forever, never drops or errors out.

Root cause: `requestSocksConnection` in `MTTcpConnection.m` hardcoded `req.AddrType = 1` (IPv4) and nevern value. When _`scheme.address.ip` is an IPv6 literal, `inet_aton` fails silently, leaving `req.DestAddr.IPv4` holding uninitialized stack garbage which still got sent to the proxy tagged as can't route the connect to a real address, so it just hangs indefinitely instead of failing.

Depends on which DC address the client resolves to (IPv4 vs IPv6), not on whether the proxy server itself supports IPv6.

## Fix

Detect IPv4 vs IPv6 properly before building the connect request, mirroring the pattern already used in -start for _socksIp/_mtpIp:

- `inet_aton` succeeds - IPv4 (ATYP=1)
- else `inet_pton(AF_INET6, ...)` succeeds - IPv6 (ATYP=4)
- else domain name fallback (ATYP=3) per SOCKS5 spec (RFC 1928 part 4), bounds-checked against the 256-byte domain buffer
- none of these parse - log and close the connection with an error, instead of sending garbage

## Impact

SOCKS5 proxy connections no longer hang indefinitely when the resolved DC address is IPv6.

## Note

Upstream has PR #735 addressing this same issue, currently under discussion.
Part of tracking issue: #182 

## Testing

- [x] Tested on iOS Simulator 18.6/26.5
- [x] SOCKS5 proxy with DC IPv6 address is connecting