### PR TITLE
Fix Proxy: proxy settings not reactively applied in UnauthorizedAccount

### DIFF
--- a/submodules/TelegramCore/Sources/Account/Account.swift
+++ b/submodules/TelegramCore/Sources/Account/Account.swift
@@ -90,7 +90,10 @@ public class UnauthorizedAccount {
     }
     
     public let shouldBeServiceTaskMaster = Promise<AccountServiceTaskMasterMode>()
-    
+
+    // MARK: Swiftgram
+    private let proxyDisposable = MetaDisposable()
+
     init(accountManager: AccountManager<TelegramAccountManagerTypes>, networkArguments: NetworkInitializationArguments, id: AccountRecordId, rootPath: String, basePath: String, testingEnvironment: Bool, postbox: Postbox, network: Network, shouldKeepAutoConnection: Bool = true) {
         self.networkArguments = networkArguments
         self.id = id
@@ -208,8 +211,42 @@ public class UnauthorizedAccount {
             }
             network.context.beginExplicitBackupAddressDiscovery()
         })
-        
+
+        // MARK: Swiftgram
+        self.proxyDisposable.set((accountManager.sharedData(keys: [SharedDataKeys.proxySettings])
+        |> map { sharedData -> ProxyServerSettings? in
+            if let settings = sharedData.entries[SharedDataKeys.proxySettings]?.get(ProxySettings.self) {
+                return settings.effectiveActiveServer
+            } else {
+                return nil
+            }
+        }
+        |> distinctUntilChanged).start(next: { activeServer in
+            let updated = activeServer.flatMap { activeServer -> MTSocksProxySettings? in
+                return activeServer.mtProxySettings
+            }
+            network.context.updateApiEnvironment { environment in
+                let current = environment?.socksProxySettings
+                let updateNetwork: Bool
+                if let current = current, let updated = updated {
+                    updateNetwork = !current.isEqual(updated)
+                } else {
+                    updateNetwork = (current != nil) != (updated != nil)
+                }
+                if updateNetwork {
+                    network.dropConnectionStatus()
+                    return environment?.withUpdatedSocksProxySettings(updated)
+                } else {
+                    return nil
+                }
+            }
+        }))
+
         self.stateManager.reset()
+    }
+
+    deinit {
+        self.proxyDisposable.dispose()
     }
     
     public func changedMasterDatacenterId(accountManager: AccountManager<TelegramAccountManagerTypes>, masterDatacenterId: Int32) -> Signal<UnauthorizedAccount, NoError> {


### PR DESCRIPTION
## Problem

If user changes/switch proxy settings mid-login before authorization completes, the change isn't picked up and the app keeps using the proxy config it had at login start. Only workaround: restart the app.

Root cause: `Account` (post-login) already has a reactive subscription to `SharedDataKeys.proxySettings` that pushes proxy changes into the live MTProto network environment. `UnauthorizedAccount` (pre-login) had no equivalent, proxy settings were read once at init and effectively frozen for the rest of the login flow.

## Fix

Add the same reactive subscription to `UnauthorizedAccount` that `Account` already has:
- subscribe to `SharedDataKeys.proxySettings`, `distinctUntilChanged`
- on change, compare current vs updated `MTSocksProxySettings`
- if different, drop connection status and push the updated settings into network.context's API env

Tracked with `MetaDisposable`, disposed in `deinit`.

## Impact

Switching/changing SOCKS5 proxy mid-login now takes effect immediately, no app restart needed.

## Note

Part of tracking issue: #182 

## Testing

- [x] Tested on iOS Simulator 18.6/26.5
- [x] Start login flow, open proxy connection settings, set proxy, confirm connection recovers without restart app