### PR TITLE
Feature: add option to hide avatar story ring

### DIFF
--- a/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
+++ b/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
@@ -54,6 +54,7 @@ private enum SGBoolSetting: String {
     case foldersAtBottom
     case startTelescopeWithRearCam
     case hideStories
+    case hideAvatarStoryRing
     case uploadSpeedBoost
     case showProfileId
     case warnOnStoriesOpen
@@ -206,6 +207,7 @@ private func SGControllerEntries(presentationData: PresentationData, callListSet
     
     entries.append(.header(id: id.count, section: .stories, text: strings.AutoDownloadSettings_Stories.uppercased(), badge: nil))
     entries.append(.toggle(id: id.count, section: .stories, settingName: .hideStories, value: SGSimpleSettings.shared.hideStories, text: i18n("Settings.Stories.Hide", lang), enabled: true))
+    entries.append(.toggle(id: id.count, section: .stories, settingName: .hideAvatarStoryRing, value: SGSimpleSettings.shared.hideAvatarStoryRing, text: i18n("Settings.Stories.HideAvatarStoryRing", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .stories, settingName: .disableSwipeToRecordStory, value: SGSimpleSettings.shared.disableSwipeToRecordStory, text: i18n("Settings.Stories.DisableSwipeToRecord", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .stories, settingName: .warnOnStoriesOpen, value: SGSimpleSettings.shared.warnOnStoriesOpen, text: i18n("Settings.Stories.WarnBeforeView", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .stories, settingName: .showRepostToStory, value: SGSimpleSettings.shared.showRepostToStoryV2, text: strings.Share_RepostToStory.replacingOccurrences(of: "\n", with: " "), enabled: true))
@@ -400,6 +402,8 @@ public func sgSettingsController(context: AccountContext/*, focusOnItemTag: Int?
             SGSimpleSettings.shared.startTelescopeWithRearCam = value
         case .hideStories:
             SGSimpleSettings.shared.hideStories = value
+        case .hideAvatarStoryRing:
+            SGSimpleSettings.shared.hideAvatarStoryRing = value
         case .showProfileId:
             SGSimpleSettings.shared.showProfileId = value
         case .warnOnStoriesOpen:

--- a/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
+++ b/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
@@ -173,6 +173,7 @@ public class SGSimpleSettings {
         case wideTabBar
         case tabBarSearchEnabled
         case hideStories
+        case hideAvatarStoryRing
         case warnOnStoriesOpen
         case showProfileId
         case sendWithReturnKey
@@ -326,6 +327,7 @@ public class SGSimpleSettings {
         Keys.wideTabBar.rawValue: false,
         Keys.tabBarSearchEnabled.rawValue: true,
         Keys.hideStories.rawValue: false,
+        Keys.hideAvatarStoryRing.rawValue: false,
         Keys.warnOnStoriesOpen.rawValue: false,
         Keys.showProfileId.rawValue: true,
         Keys.sendWithReturnKey.rawValue: false
@@ -382,6 +384,9 @@ public class SGSimpleSettings {
 
     @UserDefault(key: Keys.hideStories.rawValue)
     public var hideStories: Bool
+
+    @UserDefault(key: Keys.hideAvatarStoryRing.rawValue)
+    public var hideAvatarStoryRing: Bool
 
     @UserDefault(key: Keys.warnOnStoriesOpen.rawValue)
     public var warnOnStoriesOpen: Bool

--- a/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
@@ -39,6 +39,7 @@
 "Settings.Profiles.Header" = "PROFILES";
 
 "Settings.Stories.Hide" = "Hide Stories";
+"Settings.Stories.HideAvatarStoryRing" = "Hide Avatar Story Ring";
 "Settings.Stories.WarnBeforeView" = "Ask Before Viewing";
 "Settings.Stories.DisableSwipeToRecord" = "Disable Swipe to Record";
 

--- a/submodules/AvatarNode/BUILD
+++ b/submodules/AvatarNode/BUILD
@@ -1,11 +1,15 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
+sgsrcs = [
+    "//Swiftgram/SGChatListSimpleSettingsSignal:SGChatListSimpleSettingsSignal",
+]
+
 swift_library(
     name = "AvatarNode",
     module_name = "AvatarNode",
     srcs = glob([
         "Sources/**/*.swift",
-    ]),
+    ]) + sgsrcs,
     copts = [
         "-warnings-as-errors",
     ],
@@ -24,6 +28,7 @@ swift_library(
         "//submodules/ComponentFlow",
         "//submodules/TelegramUI/Components/Stories/AvatarStoryIndicatorComponent",
         "//submodules/DirectMediaImageCache",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/AvatarNode/Sources/AvatarNode.swift
+++ b/submodules/AvatarNode/Sources/AvatarNode.swift
@@ -14,6 +14,7 @@ import Accelerate
 import ComponentFlow
 import AvatarStoryIndicatorComponent
 import DirectMediaImageCache
+import SGSimpleSettings
 
 private let deletedIcon = UIImage(bundleImageName: "Avatar/DeletedIcon")?.precomposed()
 private let phoneIcon = generateTintedImage(image: UIImage(bundleImageName: "Avatar/PhoneIcon"), color: .white)
@@ -1183,6 +1184,10 @@ public final class AvatarNode: ASDisplayNode {
     }
     
     public private(set) var storyStats: StoryStats?
+    // MARK: Swiftgram
+    private var rawStoryStats: StoryStats?
+    private var hideAvatarStoryRingDisposable: MetaDisposable?
+    //
     
     public var font: UIFont {
         get {
@@ -1235,12 +1240,15 @@ public final class AvatarNode: ASDisplayNode {
             }
             self.updateStoryIndicator(transition: .immediate)
         }
-        
+
         self.addSubnode(self.contentNode)
     }
-    
+
     deinit {
         self.cancelLoading()
+        // MARK: Swiftgram
+        self.hideAvatarStoryRingDisposable?.dispose()
+        //
     }
     
     override public var frame: CGRect {
@@ -1374,13 +1382,38 @@ public final class AvatarNode: ASDisplayNode {
     }
     
     public func setStoryStats(storyStats: StoryStats?, presentationParams: StoryPresentationParams, transition: ComponentTransition) {
-        if self.storyStats != storyStats || self.storyPresentationParams != presentationParams {
-            self.storyStats = storyStats
+        self.applyStoryStats(storyStats: storyStats, presentationParams: presentationParams, transition: transition)
+    }
+
+    // MARK: Swiftgram
+    private func applyStoryStats(storyStats: StoryStats?, presentationParams: StoryPresentationParams?, transition: ComponentTransition) {
+        self.rawStoryStats = storyStats
+        if storyStats != nil {
+            if self.hideAvatarStoryRingDisposable == nil {
+                let disposable = MetaDisposable()
+                self.hideAvatarStoryRingDisposable = disposable
+                disposable.set((sgSimpleSettingsBoolSignal(.hideAvatarStoryRing, defaultValue: false)
+                |> deliverOnMainQueue).startStrict(next: { [weak self] _ in
+                    guard let self else {
+                        return
+                    }
+                    self.applyStoryStats(storyStats: self.rawStoryStats, presentationParams: self.storyPresentationParams, transition: .immediate)
+                }))
+            }
+        } else {
+            self.hideAvatarStoryRingDisposable?.dispose()
+            self.hideAvatarStoryRingDisposable = nil
+        }
+
+        let filteredStoryStats = SGSimpleSettings.shared.hideAvatarStoryRing ? nil : storyStats
+        if self.storyStats != filteredStoryStats || self.storyPresentationParams != presentationParams {
+            self.storyStats = filteredStoryStats
             self.storyPresentationParams = presentationParams
-            
+
             self.updateStoryIndicator(transition: transition)
         }
     }
+    //
     
     public struct Colors: Equatable {
         public var unseenColors: [UIColor]

--- a/submodules/ChatListUI/Sources/Node/ChatListItem.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListItem.swift
@@ -1901,7 +1901,9 @@ public class ChatListItemNode: ItemListRevealOptionsItemNode {
             lineWidth: 2.33,
             inactiveLineWidth: 1.33
         ), transition: .immediate)
-        self.avatarNode.isUserInteractionEnabled = !item.useCommunityViewLayout && ((storyState != nil && !peerIsCommunity) || peerLinkedCommunityId != nil)
+        // MARK: Swiftgram
+        self.avatarNode.isUserInteractionEnabled = !item.useCommunityViewLayout && ((self.avatarNode.storyStats != nil && !peerIsCommunity) || peerLinkedCommunityId != nil)
+        //
         
         if let stats = storyState?.stats, stats.hasLiveItems {
             if self.avatarLiveBadge == nil {

--- a/submodules/ContactsPeerItem/Sources/ContactsPeerItem.swift
+++ b/submodules/ContactsPeerItem/Sources/ContactsPeerItem.swift
@@ -1372,7 +1372,9 @@ public class ContactsPeerItemNode: ItemListRevealOptionsItemNode {
                                 strongSelf.avatarTapRecognizer = avatarTapRecognizer
                                 strongSelf.avatarNode.view.addGestureRecognizer(avatarTapRecognizer)
                             }
-                            strongSelf.avatarNode.isUserInteractionEnabled = item.storyStats != nil
+                            // MARK: Swiftgram
+                            strongSelf.avatarNode.isUserInteractionEnabled = strongSelf.avatarNode.storyStats != nil
+                            //
                             
                             let transition: ContainedViewLayoutTransition
                             if animated {


### PR DESCRIPTION
## Summary

- New settings toggle `Settings.Stories.HideAvatarStoryRing` (Settings -> Stories -> "Hide Avatar Story Ring") hides the story ring around avatars everywhere `AvatarNode` renders one (chat list, archived chats, contacts/search, etc.)
- `AvatarNode` lazily subscribes to the setting only while it holds non-nil `storyStats`, and filters the ring out on toggle without re-fetching data
- Chat header avatar ring (`ChatAvatarNavigationNode`) is untouched because that's already governed by the existing "Hide Stories" toggle

## Screenshots

<details>
  <summary>Toggle "Hide Avatar Story Ring" in Settings -> Stories</summary>
  <img width="384" height="392" alt="image" src="https://github.com/user-attachments/assets/c646fa00-6904-4f66-802e-fa0671797285" />
</details>

## Testing

- [x] Tested on iOS Simulator 18.6/26.5
- [x] Toggle "Hide Avatar Story Ring" in Settings -> Stories
- [x] Verified story ring disappears on avatars
