### PR TITLE
Feature: add option to hide AI Rewrite button

### DIFF
--- a/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
+++ b/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
@@ -82,6 +82,7 @@ private enum SGBoolSetting: String {
     case disableGalleryCamera
     case disableGalleryCameraPreview
     case disableSendAsButton
+    case disableAIChatButton
     case disableSnapDeletionEffect
     case stickerTimestamp
     case hideRecordingButton
@@ -314,6 +315,7 @@ private func SGControllerEntries(presentationData: PresentationData, callListSet
     entries.append(.toggle(id: id.count, section: .other, settingName: .hideRecordingButton, value: !SGSimpleSettings.shared.hideRecordingButton, text: i18n("Settings.RecordingButton", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableSnapDeletionEffect, value: !SGSimpleSettings.shared.disableSnapDeletionEffect, text: i18n("Settings.SnapDeletionEffect", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableSendAsButton, value: !SGSimpleSettings.shared.disableSendAsButton, text: i18n("Settings.SendAsButton", lang, strings.Conversation_SendMesageAs), enabled: true))
+    entries.append(.toggle(id: id.count, section: .other, settingName: .disableAIChatButton, value: !SGSimpleSettings.shared.disableAIChatButton, text: i18n("Settings.AIChatButton", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableGalleryCamera, value: !SGSimpleSettings.shared.disableGalleryCamera, text: i18n("Settings.GalleryCamera", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableGalleryCameraPreview, value: !SGSimpleSettings.shared.disableGalleryCameraPreview, text: i18n("Settings.GalleryCameraPreview", lang), enabled: !SGSimpleSettings.shared.disableGalleryCamera))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableScrollToNextChannel, value: !SGSimpleSettings.shared.disableScrollToNextChannel, text: i18n("Settings.PullToNextChannel", lang), enabled: true))
@@ -448,6 +450,8 @@ public func sgSettingsController(context: AccountContext/*, focusOnItemTag: Int?
             SGSimpleSettings.shared.disableGalleryCameraPreview = !value
         case .disableSendAsButton:
             SGSimpleSettings.shared.disableSendAsButton = !value
+        case .disableAIChatButton:
+            SGSimpleSettings.shared.disableAIChatButton = !value
         case .disableSnapDeletionEffect:
             SGSimpleSettings.shared.disableSnapDeletionEffect = !value
         case .contextShowReport:

--- a/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
+++ b/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
@@ -131,6 +131,7 @@ public class SGSimpleSettings {
         case disableGalleryCamera
         case disableGalleryCameraPreview
         case disableSendAsButton
+        case disableAIChatButton
         case disableSnapDeletionEffect
         case stickerSize
         case stickerTimestamp
@@ -289,6 +290,7 @@ public class SGSimpleSettings {
         Keys.disableGalleryCamera.rawValue: false,
         Keys.disableGalleryCameraPreview.rawValue: false,
         Keys.disableSendAsButton.rawValue: false,
+        Keys.disableAIChatButton.rawValue: false,
         Keys.disableSnapDeletionEffect.rawValue: false,
         Keys.stickerSize.rawValue: 100,
         Keys.stickerTimestamp.rawValue: true,
@@ -463,6 +465,9 @@ public class SGSimpleSettings {
 
     @UserDefault(key: Keys.disableSendAsButton.rawValue)
     public var disableSendAsButton: Bool
+
+    @UserDefault(key: Keys.disableAIChatButton.rawValue)
+    public var disableAIChatButton: Bool
 
     @UserDefault(key: Keys.disableSnapDeletionEffect.rawValue)
     public var disableSnapDeletionEffect: Bool

--- a/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
@@ -135,6 +135,7 @@
 "Settings.GalleryCameraPreview" = "Camera Preview in Gallery";
 /* "Send Message As..." button */
 "Settings.SendAsButton" = "\"%@\" Button";
+"Settings.AIChatButton" = "AI Rewrite Button";
 "Settings.SnapDeletionEffect" = "Message Deletion Effects";
 
 "Settings.Stickers.Size" = "SIZE";

--- a/submodules/TelegramUI/Components/Chat/ChatTextInputPanelNode/Sources/ChatTextInputPanelNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatTextInputPanelNode/Sources/ChatTextInputPanelNode.swift
@@ -3578,7 +3578,7 @@ public class ChatTextInputPanelNode: ChatInputPanelNode, ASEditableTextNodeDeleg
         var isAIButtonVisible = false
         var attachmentPillHeight: CGFloat = 40.0
         let inputHasNonWhitespaceText = !(self.richTextInputNode?.inputContentIsEmptyWhitespaceTrimmed ?? true)
-        if self.isAIEnabled, inputHasNonWhitespaceText, let node = self.richTextInputNode {
+        if self.isAIEnabled && !SGSimpleSettings.shared.disableAIChatButton, inputHasNonWhitespaceText, let node = self.richTextInputNode {
             let threeLineHeight = self.threeLineFieldHeight(forWidth: baseWidth, node: node, metrics: metrics, bottomInset: bottomInset, textFieldInsets: textFieldInsets)
             if textInputHeight >= threeLineHeight - 0.5 {
                 isAIButtonVisible = true
@@ -3600,7 +3600,7 @@ public class ChatTextInputPanelNode: ChatInputPanelNode, ASEditableTextNodeDeleg
         }
 
         // AI button in the TOP 40x40 slot of the capsule (fades in with the 3-line rule).
-        if self.isAIEnabled {
+        if self.isAIEnabled && !SGSimpleSettings.shared.disableAIChatButton {
             let aiButton: (button: HighlightTrackingButton, icon: UIImageView)
             if let current = self.attachmentAIButton {
                 aiButton = current


### PR DESCRIPTION
Closes #173 

## Summary

- New option toggle in Settings -> Other: `disableAIChatButton` (button shown by default)
- Gates the AI button in `ChatTextInputPanelNode`: both the pill-visibility trigger and the actual `attachmentAIButton` creation/display, behind `!SGSimpleSettings.shared.disableAIChatButton`
- String: `Settings.AIChatButton` = "AI Rewrite Button"

## Screenshots

<details>
  <summary>Option toggle "AI Rewrite Button" in Settings -> Other</summary>
  <img width="415" height="348" alt="image" src="https://github.com/user-attachments/assets/978cd255-30e7-4d81-8402-03e13327cbbf" />
</details>

<details>
  <summary>Toggle on</summary>
  <img width="398" height="99" alt="image" src="https://github.com/user-attachments/assets/b723275e-5af4-4e43-bfbf-a399505badf7" />
</details>

<details>
  <summary>Toggle off</summary>
  <img width="401" height="107" alt="image" src="https://github.com/user-attachments/assets/97dcce16-c9dc-4d11-ae92-0ec5cdf99650" />
</details>

## Testing

- [x] Tested on iOS Simulator 18.6/26.5
- [x] Toggle off: AI Rewrite button disappears from chat input panel
- [x] Toggle on: button reappears, width calc still correct