### PR TITLE
Feature: add option to hide premium badge

### DIFF
--- a/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
+++ b/Swiftgram/SGSettingsUI/Sources/SGSettingsController.swift
@@ -85,6 +85,7 @@ private enum SGBoolSetting: String {
     case disableSnapDeletionEffect
     case stickerTimestamp
     case hideRecordingButton
+    case hidePremiumBadge
     case hideTabBar
     case showDC
     case showCreationDate
@@ -312,6 +313,7 @@ private func SGControllerEntries(presentationData: PresentationData, callListSet
     entries.append(.toggle(id: id.count, section: .other, settingName: .secondsInMessages, value: SGSimpleSettings.shared.secondsInMessages, text: i18n("Settings.secondsInMessages", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .messageDoubleTapActionOutgoingEdit, value: SGSimpleSettings.shared.messageDoubleTapActionOutgoing == SGSimpleSettings.MessageDoubleTapAction.edit.rawValue, text: i18n("Settings.messageDoubleTapActionOutgoingEdit", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .hideRecordingButton, value: !SGSimpleSettings.shared.hideRecordingButton, text: i18n("Settings.RecordingButton", lang), enabled: true))
+    entries.append(.toggle(id: id.count, section: .other, settingName: .hidePremiumBadge, value: !SGSimpleSettings.shared.hidePremiumBadge, text: i18n("Settings.PremiumBadge", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableSnapDeletionEffect, value: !SGSimpleSettings.shared.disableSnapDeletionEffect, text: i18n("Settings.SnapDeletionEffect", lang), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableSendAsButton, value: !SGSimpleSettings.shared.disableSendAsButton, text: i18n("Settings.SendAsButton", lang, strings.Conversation_SendMesageAs), enabled: true))
     entries.append(.toggle(id: id.count, section: .other, settingName: .disableGalleryCamera, value: !SGSimpleSettings.shared.disableGalleryCamera, text: i18n("Settings.GalleryCamera", lang), enabled: true))
@@ -466,6 +468,9 @@ public func sgSettingsController(context: AccountContext/*, focusOnItemTag: Int?
             SGSimpleSettings.shared.contextShowJson = value
         case .hideRecordingButton:
             SGSimpleSettings.shared.hideRecordingButton = !value
+        case .hidePremiumBadge:
+            SGSimpleSettings.shared.hidePremiumBadge = !value
+            askForRestart?()
         case .hideTabBar:
             SGSimpleSettings.shared.hideTabBar = value
             simplePromise.set(true) // Trigger update for 'enabled' field of other toggles

--- a/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
+++ b/Swiftgram/SGSimpleSettings/Sources/SimpleSettings.swift
@@ -135,6 +135,7 @@ public class SGSimpleSettings {
         case stickerSize
         case stickerTimestamp
         case hideRecordingButton
+        case hidePremiumBadge
         case hideTabBar
         case showDC
         case showCreationDate
@@ -293,6 +294,7 @@ public class SGSimpleSettings {
         Keys.stickerSize.rawValue: 100,
         Keys.stickerTimestamp.rawValue: true,
         Keys.hideRecordingButton.rawValue: false,
+        Keys.hidePremiumBadge.rawValue: false,
         Keys.hideTabBar.rawValue: false,
         Keys.showDC.rawValue: false,
         Keys.showCreationDate.rawValue: true,
@@ -475,6 +477,9 @@ public class SGSimpleSettings {
 
     @UserDefault(key: Keys.hideRecordingButton.rawValue)
     public var hideRecordingButton: Bool
+
+    @UserDefault(key: Keys.hidePremiumBadge.rawValue)
+    public var hidePremiumBadge: Bool
     
     @UserDefault(key: Keys.hideTabBar.rawValue)
     public var hideTabBar: Bool

--- a/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
+++ b/Swiftgram/SGStrings/Strings/en.lproj/SGLocalizable.strings
@@ -141,6 +141,7 @@
 "Settings.Stickers.Timestamp" = "Show Timestamp";
 
 "Settings.RecordingButton" = "Voice Recording Button";
+"Settings.PremiumBadge" = "Premium Badge";
 
 "Settings.DefaultEmojisFirst" = "Standard emojis first";
 "Settings.DefaultEmojisFirst.Notice" = "Show standard emojis before premium in emoji keyboard";

--- a/submodules/CallListUI/BUILD
+++ b/submodules/CallListUI/BUILD
@@ -37,6 +37,7 @@ swift_library(
         "//submodules/TelegramUI/Components/EdgeEffect",
         "//submodules/ComponentFlow",
         "//submodules/Components/ComponentDisplayAdapters",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/CallListUI/Sources/CallListCallItem.swift
+++ b/submodules/CallListUI/Sources/CallListCallItem.swift
@@ -4,6 +4,7 @@ import AsyncDisplayKit
 import Display
 import SwiftSignalKit
 import TelegramCore
+import SGSimpleSettings
 import TelegramPresentationData
 import ItemListUI
 import PresentationDataUtils
@@ -539,7 +540,7 @@ class CallListCallItemNode: ItemListRevealOptionsItemNode {
                     currentCredibilityIconImage = PresentationResourcesChatList.fakeIcon(item.presentationData.theme, strings: item.presentationData.strings, type: .regular)
                 } else if peer.isVerified {
                     currentCredibilityIconImage = PresentationResourcesChatList.verifiedIcon(item.presentationData.theme)
-                } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                     currentCredibilityIconImage = PresentationResourcesChatList.premiumIcon(item.presentationData.theme)
                 }
             }

--- a/submodules/ChatListUI/Sources/ChatListController.swift
+++ b/submodules/ChatListUI/Sources/ChatListController.swift
@@ -6912,9 +6912,9 @@ private final class ChatListLocationContext {
                 guard case let .user(user) = peer else {
                     return nil
                 }
-                if let emojiStatus = user.emojiStatus {
+                if let emojiStatus = user.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     return .emoji(emojiStatus)
-                } else if user.isPremium {
+                } else if user.isPremium && !SGSimpleSettings.shared.hidePremiumBadge {
                     return .premium
                 } else {
                     return nil

--- a/submodules/ChatListUI/Sources/Node/ChatListItem.swift
+++ b/submodules/ChatListUI/Sources/Node/ChatListItem.swift
@@ -3570,12 +3570,12 @@ public class ChatListItemNode: ItemListRevealOptionsItemNode {
                                 currentCredibilityIconContent = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased())
                             } else if peer.isFake {
                                 currentCredibilityIconContent = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
-                            } else if let emojiStatus = peer.emojiStatus {
+                            } else if let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                                 currentStatusIconContent = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 32.0, height: 32.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
                                 if let color = emojiStatus.color {
                                     currentStatusIconParticleColor = UIColor(rgb: UInt32(bitPattern: color))
                                 }
-                            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                                 currentCredibilityIconContent = .premium(color: item.presentationData.theme.list.itemAccentColor)
                             }
                             
@@ -3601,12 +3601,12 @@ public class ChatListItemNode: ItemListRevealOptionsItemNode {
                         currentCredibilityIconContent = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased())
                     } else if peer.isFake {
                         currentCredibilityIconContent = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
-                    } else if let emojiStatus = peer.emojiStatus {
+                    } else if let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                         currentStatusIconContent = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 32.0, height: 32.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
                         if let color = emojiStatus.color {
                             currentStatusIconParticleColor = UIColor(rgb: UInt32(bitPattern: color))
                         }
-                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                         currentCredibilityIconContent = .premium(color: item.presentationData.theme.list.itemAccentColor)
                     }
                     

--- a/submodules/Components/ReactionListContextMenuContent/BUILD
+++ b/submodules/Components/ReactionListContextMenuContent/BUILD
@@ -27,6 +27,7 @@ swift_library(
         "//submodules/TelegramUI/Components/EmojiTextAttachmentView:EmojiTextAttachmentView",
         "//submodules/TelegramUI/Components/EmojiStatusComponent:EmojiStatusComponent",
         "//submodules/TextFormat:TextFormat",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/Components/ReactionListContextMenuContent/Sources/ReactionListContextMenuContent.swift
+++ b/submodules/Components/ReactionListContextMenuContent/Sources/ReactionListContextMenuContent.swift
@@ -4,6 +4,7 @@ import Display
 import ComponentFlow
 import MultilineTextComponent
 import SwiftSignalKit
+import SGSimpleSettings
 import TelegramCore
 import AccountContext
 import TelegramPresentationData
@@ -639,11 +640,11 @@ public final class ReactionListContextMenuContent: ContextControllerItemsContent
                     currentCredibilityIcon = .text(color: presentationData.theme.chat.message.incoming.scamColor, string: presentationData.strings.Message_ScamAccount.uppercased())
                 } else if item.peer.isFake {
                     currentCredibilityIcon = .text(color: presentationData.theme.chat.message.incoming.scamColor, string: presentationData.strings.Message_FakeAccount.uppercased())
-                } else if let emojiStatus = item.peer.emojiStatus {
+                } else if let emojiStatus = item.peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     currentCredibilityIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 32.0, height: 32.0), placeholderColor: UIColor(white: 0.0, alpha: 0.1), themeColor: presentationData.theme.list.itemAccentColor, loopMode: .count(2))
                 } else if item.peer.isVerified {
                     currentCredibilityIcon = .verified(fillColor: presentationData.theme.list.itemCheckColors.fillColor, foregroundColor: presentationData.theme.list.itemCheckColors.foregroundColor, sizeType: .compact)
-                } else if item.peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                } else if item.peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                     currentCredibilityIcon = .premium(color: presentationData.theme.list.itemCheckColors.fillColor)
                 }
                 

--- a/submodules/ContactsPeerItem/BUILD
+++ b/submodules/ContactsPeerItem/BUILD
@@ -34,6 +34,7 @@ swift_library(
         "//submodules/MoreButtonNode",
         "//submodules/TextFormat",
         "//submodules/TelegramUI/Components/TextNodeWithEntities",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/ContactsPeerItem/Sources/ContactsPeerItem.swift
+++ b/submodules/ContactsPeerItem/Sources/ContactsPeerItem.swift
@@ -4,6 +4,7 @@ import AsyncDisplayKit
 import Display
 import SwiftSignalKit
 import TelegramCore
+import SGSimpleSettings
 import TelegramPresentationData
 import TelegramUIPreferences
 import ItemListUI
@@ -867,12 +868,12 @@ public class ContactsPeerItemNode: ItemListRevealOptionsItemNode {
                         credibilityStatusIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased())
                     } else if peer.isFake {
                         credibilityStatusIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
-                    } else if let emojiStatus = peer.emojiStatus, !item.isAd {
+                    } else if let emojiStatus = peer.emojiStatus, !item.isAd, !SGSimpleSettings.shared.hidePremiumBadge {
                         emojiStatusIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
                         if let color = emojiStatus.color {
                             emojiStatusParticleColor = UIColor(rgb: UInt32(bitPattern: color))
                         }
-                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                         credibilityStatusIcon = .premium(color: item.presentationData.theme.list.itemAccentColor)
                     }
                     

--- a/submodules/ItemListAvatarAndNameInfoItem/BUILD
+++ b/submodules/ItemListAvatarAndNameInfoItem/BUILD
@@ -25,6 +25,7 @@ swift_library(
         "//submodules/PhoneNumberFormat:PhoneNumberFormat",
         "//submodules/AccountContext:AccountContext",
         "//submodules/TelegramUI/Components/ListItemComponentAdaptor",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/ItemListAvatarAndNameInfoItem/Sources/ItemListAvatarAndNameItem.swift
+++ b/submodules/ItemListAvatarAndNameInfoItem/Sources/ItemListAvatarAndNameItem.swift
@@ -4,6 +4,7 @@ import Display
 import AsyncDisplayKit
 import TelegramCore
 import SwiftSignalKit
+import SGSimpleSettings
 import TelegramPresentationData
 import ItemListUI
 import PresentationDataUtils
@@ -441,7 +442,7 @@ public class ItemListAvatarAndNameInfoItemNode: ListViewItemNode, ItemListItemNo
                     credibilityIconOffset = 2.0
                 } else if peer.isVerified {
                     credibilityIconImage = PresentationResourcesItemList.verifiedPeerIcon(item.presentationData.theme)
-                } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                     credibilityIconImage = PresentationResourcesChatList.premiumIcon(item.presentationData.theme)
                 }
             }

--- a/submodules/ItemListPeerItem/BUILD
+++ b/submodules/ItemListPeerItem/BUILD
@@ -29,6 +29,7 @@ swift_library(
         "//submodules/TelegramUI/Components/AnimationCache",
         "//submodules/TelegramUI/Components/MultiAnimationRenderer",
         "//submodules/TelegramUI/Components/TextNodeWithEntities",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/ItemListPeerItem/Sources/ItemListPeerItem.swift
+++ b/submodules/ItemListPeerItem/Sources/ItemListPeerItem.swift
@@ -4,6 +4,7 @@ import Display
 import AsyncDisplayKit
 import SwiftSignalKit
 import TelegramCore
+import SGSimpleSettings
 import TelegramPresentationData
 import TelegramUIPreferences
 import ItemListUI
@@ -938,12 +939,12 @@ public class ItemListPeerItemNode: ItemListRevealOptionsItemNode, ItemListItemNo
                     credibilityIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased())
                 } else if item.peer.isFake {
                     credibilityIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
-                } else if let emojiStatus = item.peer.emojiStatus {
+                } else if let emojiStatus = item.peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     credibilityIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
                     if let color = emojiStatus.color {
                         credibilityParticleColor = UIColor(rgb: UInt32(bitPattern: color))
                     }
-                } else if item.peer.isPremium && !item.context.isPremiumDisabled {
+                } else if item.peer.isPremium && !item.context.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                     credibilityIcon = .premium(color: item.presentationData.theme.list.itemAccentColor)
                 }
                 

--- a/submodules/TelegramCallsUI/BUILD
+++ b/submodules/TelegramCallsUI/BUILD
@@ -41,7 +41,8 @@ apple_resource_bundle(
 )
 
 sgdeps = [
-    "//Swiftgram/SGAppGroupIdentifier:SGAppGroupIdentifier"
+    "//Swiftgram/SGAppGroupIdentifier:SGAppGroupIdentifier",
+    "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
 ]
 
 swift_library(

--- a/submodules/TelegramCallsUI/Sources/VoiceChatParticipantItem.swift
+++ b/submodules/TelegramCallsUI/Sources/VoiceChatParticipantItem.swift
@@ -4,6 +4,7 @@ import Display
 import AsyncDisplayKit
 import SwiftSignalKit
 import TelegramCore
+import SGSimpleSettings
 import TelegramPresentationData
 import TelegramUIPreferences
 import ItemListUI
@@ -840,11 +841,11 @@ class VoiceChatParticipantItemNode: ItemListRevealOptionsItemNode {
                 credibilityIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased())
             } else if item.peer.isFake {
                 credibilityIcon = .text(color: item.presentationData.theme.chat.message.incoming.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased())
-            } else if let emojiStatus = item.peer.emojiStatus {
+            } else if let emojiStatus = item.peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                 credibilityIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: item.presentationData.theme.list.mediaPlaceholderColor, themeColor: item.presentationData.theme.list.itemAccentColor, loopMode: .count(2))
             } else if item.peer.isVerified {
                 credibilityIcon = .verified(fillColor: item.presentationData.theme.list.itemCheckColors.fillColor, foregroundColor: item.presentationData.theme.list.itemCheckColors.foregroundColor, sizeType: .compact)
-            } else if item.peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+            } else if item.peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                 credibilityIcon = .premium(color: item.presentationData.theme.list.itemAccentColor)
             }
             

--- a/submodules/TelegramUI/Components/Chat/ChatMessageBubbleItemNode/Sources/ChatMessageBubbleItemNode.swift
+++ b/submodules/TelegramUI/Components/Chat/ChatMessageBubbleItemNode/Sources/ChatMessageBubbleItemNode.swift
@@ -2537,18 +2537,18 @@ public class ChatMessageBubbleItemNode: ChatMessageItemView, ChatMessagePreviewI
                 authorNameColor = color
 
                 if case let .peer(peerId) = item.chatLocation, let authorPeerId = item.message.author?.id, authorPeerId == peerId {
-                    if effectiveAuthor is TelegramChannel, let emojiStatus = effectiveAuthor.emojiStatus {
+                    if effectiveAuthor is TelegramChannel, let emojiStatus = effectiveAuthor.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                         currentCredibilityIcon = (.animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: incoming ? item.presentationData.theme.theme.chat.message.incoming.mediaPlaceholderColor : item.presentationData.theme.theme.chat.message.outgoing.mediaPlaceholderColor, themeColor: color.withMultipliedAlpha(0.4), loopMode: .count(2)), nil)
                     }
                 } else if effectiveAuthor.isScam {
                     currentCredibilityIcon = (.text(color: incoming ? item.presentationData.theme.theme.chat.message.incoming.scamColor : item.presentationData.theme.theme.chat.message.outgoing.scamColor, string: item.presentationData.strings.Message_ScamAccount.uppercased()), nil)
                 } else if effectiveAuthor.isFake {
                     currentCredibilityIcon = (.text(color: incoming ? item.presentationData.theme.theme.chat.message.incoming.scamColor : item.presentationData.theme.theme.chat.message.outgoing.scamColor, string: item.presentationData.strings.Message_FakeAccount.uppercased()), nil)
-                } else if let emojiStatus = effectiveAuthor.emojiStatus {
+                } else if let emojiStatus = effectiveAuthor.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     currentCredibilityIcon = (.animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: incoming ? item.presentationData.theme.theme.chat.message.incoming.mediaPlaceholderColor : item.presentationData.theme.theme.chat.message.outgoing.mediaPlaceholderColor, themeColor: color.withMultipliedAlpha(0.4), loopMode: .count(2)), emojiStatus.color.flatMap { UIColor(rgb: UInt32(bitPattern: $0)) })
                 } else if effectiveAuthor.isVerified {
                     currentCredibilityIcon = (.verified(fillColor: item.presentationData.theme.theme.list.itemCheckColors.fillColor, foregroundColor: item.presentationData.theme.theme.list.itemCheckColors.foregroundColor, sizeType: .compact), nil)
-                } else if effectiveAuthor.isPremium {
+                } else if effectiveAuthor.isPremium && !SGSimpleSettings.shared.hidePremiumBadge {
                     currentCredibilityIcon = (.premium(color: color.withMultipliedAlpha(0.4)), nil)
                 }
             }

--- a/submodules/TelegramUI/Components/ChatTitleView/BUILD
+++ b/submodules/TelegramUI/Components/ChatTitleView/BUILD
@@ -32,6 +32,7 @@ swift_library(
         "//submodules/Components/ComponentDisplayAdapters:ComponentDisplayAdapters",
         "//submodules/TelegramUI/Components/GlassBackgroundComponent",
         "//submodules/TelegramUI/Components/AnimatedTextComponent",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/TelegramUI/Components/ChatTitleView/Sources/ChatTitleComponent.swift
+++ b/submodules/TelegramUI/Components/ChatTitleView/Sources/ChatTitleComponent.swift
@@ -3,6 +3,7 @@ import UIKit
 import Display
 import ComponentFlow
 import TelegramPresentationData
+import SGSimpleSettings
 import AccountContext
 import TelegramUIPreferences
 import TelegramCore
@@ -447,9 +448,9 @@ public final class ChatTitleComponent: Component {
                                 titleCredibilityIcon = .fake
                             } else if peer.isScam {
                                 titleCredibilityIcon = .scam
-                            } else if !hidePeerStatus, let emojiStatus = peer.emojiStatus {
+                            } else if !hidePeerStatus, let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                                 titleStatusIcon = .emojiStatus(emojiStatus)
-                            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                                 titleCredibilityIcon = .premium
                             }
                             

--- a/submodules/TelegramUI/Components/ChatTitleView/Sources/ChatTitleView.swift
+++ b/submodules/TelegramUI/Components/ChatTitleView/Sources/ChatTitleView.swift
@@ -3,6 +3,7 @@ import UIKit
 import AsyncDisplayKit
 import Display
 import TelegramCore
+import SGSimpleSettings
 import SwiftSignalKit
 import LegacyComponents
 import TelegramPresentationData
@@ -308,9 +309,9 @@ public final class ChatTitleView: UIView, NavigationBarTitleView {
                                         titleCredibilityIcon = .fake
                                     } else if peer.isScam {
                                         titleCredibilityIcon = .scam
-                                    } else if !hidePeerStatus, let emojiStatus = peer.emojiStatus {
+                                    } else if !hidePeerStatus, let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                                         titleStatusIcon = .emojiStatus(emojiStatus)
-                                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                                         titleCredibilityIcon = .premium
                                     }
                                     

--- a/submodules/TelegramUI/Components/PeerInfo/AccountPeerContextItem/BUILD
+++ b/submodules/TelegramUI/Components/PeerInfo/AccountPeerContextItem/BUILD
@@ -21,6 +21,7 @@ swift_library(
         "//submodules/AvatarNode",
         "//submodules/ContextUI",
         "//submodules/AccountContext",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/TelegramUI/Components/PeerInfo/AccountPeerContextItem/Sources/AccountPeerContextItem.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/AccountPeerContextItem/Sources/AccountPeerContextItem.swift
@@ -4,6 +4,7 @@ import Display
 import AsyncDisplayKit
 import SwiftSignalKit
 import ComponentFlow
+import SGSimpleSettings
 import TelegramCore
 import TelegramPresentationData
 import PresentationDataUtils
@@ -102,13 +103,13 @@ private final class AccountPeerContextItemNode: ASDisplayNode, ContextMenuCustom
             
             var iconContent: EmojiStatusComponent.Content?
             if case let .user(user) = self.item.peer {
-                if let emojiStatus = user.emojiStatus {
+                if let emojiStatus = user.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     iconContent = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 28.0, height: 28.0), placeholderColor: self.presentationData.theme.list.mediaPlaceholderColor, themeColor: self.presentationData.theme.list.itemAccentColor, loopMode: .forever)
-                } else if user.isPremium {
+                } else if user.isPremium && !SGSimpleSettings.shared.hidePremiumBadge {
                     iconContent = .premium(color: self.presentationData.theme.list.itemAccentColor)
                 }
             } else if case let .channel(channel) = self.item.peer {
-                if let emojiStatus = channel.emojiStatus {
+                if let emojiStatus = channel.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     iconContent = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 28.0, height: 28.0), placeholderColor: self.presentationData.theme.list.mediaPlaceholderColor, themeColor: self.presentationData.theme.list.itemAccentColor, loopMode: .forever)
                 }
             }

--- a/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoHeaderNode.swift
+++ b/submodules/TelegramUI/Components/PeerInfo/PeerInfoScreen/Sources/PeerInfoHeaderNode.swift
@@ -28,6 +28,7 @@ import MultiAnimationRenderer
 import ComponentDisplayAdapters
 import ChatTitleView
 import AppBundle
+import SGSimpleSettings
 import AvatarVideoNode
 import PeerInfoVisualMediaPaneNode
 import AvatarStoryIndicatorComponent
@@ -605,9 +606,9 @@ final class PeerInfoHeaderNode: ASDisplayNode {
                 credibilityIcon = .fake
             } else if peer.isScam {
                 credibilityIcon = .scam
-            } else if let emojiStatus = peer.emojiStatus {
+            } else if let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                 statusIcon = .emojiStatus(emojiStatus)
-            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && (peer.id != self.context.account.peerId || self.isSettings || self.isMyProfile) {
+            } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge && (peer.id != self.context.account.peerId || self.isSettings || self.isMyProfile) {
                 credibilityIcon = .premium
             } else {
                 credibilityIcon = .none

--- a/submodules/TelegramUI/Components/Settings/PeerNameColorScreen/BUILD
+++ b/submodules/TelegramUI/Components/Settings/PeerNameColorScreen/BUILD
@@ -63,6 +63,7 @@ swift_library(
         "//submodules/TelegramUI/Components/Gifts/GiftViewScreen",
         "//submodules/TelegramUI/Components/Stars/BalanceNeededScreen",
         "//submodules/TelegramUI/Components/EdgeEffect",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/TelegramUI/Components/Settings/PeerNameColorScreen/Sources/PeerNameColorProfilePreviewItem.swift
+++ b/submodules/TelegramUI/Components/Settings/PeerNameColorScreen/Sources/PeerNameColorProfilePreviewItem.swift
@@ -6,6 +6,7 @@ import SwiftSignalKit
 import TelegramCore
 import TelegramPresentationData
 import TelegramUIPreferences
+import SGSimpleSettings
 import ItemListUI
 import PresentationDataUtils
 import AccountContext
@@ -311,13 +312,13 @@ final class PeerNameColorProfilePreviewItemNode: ListViewItemNode {
                         credibilityIcon = .fake
                     } else if peer.isScam {
                         credibilityIcon = .scam
-                    } else if case let .user(user) = peer, let emojiStatus = user.emojiStatus {
+                    } else if case let .user(user) = peer, let emojiStatus = user.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                         credibilityIcon = .emojiStatus(emojiStatus)
-                    } else if case let .channel(channel) = peer, let emojiStatus = channel.emojiStatus {
+                    } else if case let .channel(channel) = peer, let emojiStatus = channel.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                         credibilityIcon = .emojiStatus(emojiStatus)
                     } else if peer.isVerified {
                         credibilityIcon = .verified
-                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled {
+                    } else if peer.isPremium && !premiumConfiguration.isPremiumDisabled && !SGSimpleSettings.shared.hidePremiumBadge {
                         credibilityIcon = .premium
                     } else {
                         credibilityIcon = .none

--- a/submodules/TelegramUI/Components/Stories/PeerListItemComponent/BUILD
+++ b/submodules/TelegramUI/Components/Stories/PeerListItemComponent/BUILD
@@ -33,6 +33,7 @@ swift_library(
         "//submodules/PhotoResources",
         "//submodules/TelegramUI/Components/ListSectionComponent",
         "//submodules/TelegramUI/Components/ListItemSwipeOptionContainer",
+        "//Swiftgram/SGSimpleSettings:SGSimpleSettings",
     ],
     visibility = [
         "//visibility:public",

--- a/submodules/TelegramUI/Components/Stories/PeerListItemComponent/Sources/PeerListItemComponent.swift
+++ b/submodules/TelegramUI/Components/Stories/PeerListItemComponent/Sources/PeerListItemComponent.swift
@@ -5,6 +5,7 @@ import Display
 import AsyncDisplayKit
 import ComponentFlow
 import SwiftSignalKit
+import SGSimpleSettings
 import AccountContext
 import TelegramCore
 import MultilineTextComponent
@@ -871,14 +872,14 @@ public final class PeerListItemComponent: Component {
                     statusIcon = .text(color: component.theme.chat.message.incoming.scamColor, string: component.strings.Message_ScamAccount.uppercased())
                 } else if peer.isFake {
                     statusIcon = .text(color: component.theme.chat.message.incoming.scamColor, string: component.strings.Message_FakeAccount.uppercased())
-                } else if let emojiStatus = peer.emojiStatus {
+                } else if let emojiStatus = peer.emojiStatus, !SGSimpleSettings.shared.hidePremiumBadge {
                     statusIcon = .animation(content: .customEmoji(fileId: emojiStatus.fileId), size: CGSize(width: 20.0, height: 20.0), placeholderColor: component.theme.list.mediaPlaceholderColor, themeColor: component.theme.list.itemAccentColor, loopMode: .count(0))
                     if let color = emojiStatus.color {
                         particleColor = UIColor(rgb: UInt32(bitPattern: color))
                     }
                 } else if peer.isVerified {
                     statusIcon = .verified(fillColor: component.theme.list.itemCheckColors.fillColor, foregroundColor: component.theme.list.itemCheckColors.foregroundColor, sizeType: .compact)
-                } else if peer.isPremium {
+                } else if peer.isPremium && !SGSimpleSettings.shared.hidePremiumBadge {
                     statusIcon = .premium(color: component.theme.list.itemAccentColor)
                 }
             }


### PR DESCRIPTION
## Summary

Adds a `Settings -> Other -> Premium Badge toggle` that hides the premium emoji-status badge for users and channels.
Hides badge in:
  - Chat list
  - Chat title
  - Messages
  - Profile
  - Contact list
  - Reactions
  - Calls

## Screenshots

<details>
  <summary>Toggle in settings</summary>
  <img width="362" height="258" alt="image" src="https://github.com/user-attachments/assets/34f1993d-84d7-4218-84ba-c3b3b74cbc2c" />
</details>

## Testing

- [x] Tested on iOS Simulator 18.6/26.5
- [x] Disable toggle -> restart prompt appears -> after restart, badge/emoji-status gone everywhere
- [x] Enable toggle -> restart prompt appears again -> badges come back